### PR TITLE
feature/setup: Initializes a new Ignite database instance with configurable options.

### DIFF
--- a/pkg/filesys/filesys.go
+++ b/pkg/filesys/filesys.go
@@ -1,0 +1,269 @@
+// Package filesys provides a collection of utility functions for common file system operations.
+// It includes functions for creating, deleting, copying, reading, and searching files and directories,
+// as well as checking file existence and managing the current working directory.
+package filesys
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	ErrIsNotDir = errors.New("path isn't a directory")
+)
+
+// CreateDir creates a directory at the specified path with the given permissions.
+//
+// If the directory already exists:
+//   - If 'force' is true, it proceeds without error.
+//   - If 'force' is false, it returns an error.
+//
+// It also returns an error if the existing path is a file (not a directory).
+func CreateDir(dirPath string, permission os.FileMode, force bool) error {
+	// Get file information for the given path.
+	stat, err := os.Stat(dirPath)
+	// If 'force' is false and the path exists
+	// return the error (indicating the directory already exists).
+	if !force && !os.IsNotExist(err) {
+		return err
+	}
+
+	// If the path exists and it's not a directory, return an error.
+	if stat != nil && !stat.IsDir() {
+		return ErrIsNotDir
+	}
+
+	// Create all necessary parent directories if they don't exist, with the specified permissions.
+	if err := os.MkdirAll(dirPath, permission); err != nil {
+		return err
+	}
+
+	// Change the permissions of the newly created directory to 0755 (rwxr-xr-x).
+	return os.Chmod(dirPath, 0755)
+}
+
+// DeleteDir deletes a directory and all its contents recursively.
+// It returns any error encountered during the removal.
+func DeleteDir(path string) error {
+	return os.RemoveAll(path)
+}
+
+// CopyDir copies the entire contents of a source directory to a destination directory.
+// It preserves the file modes of the source directory and files.
+// It returns an error if the source is not a directory or if any other I/O operation fails.
+func CopyDir(src, dest string) error {
+	// Get file information for the source path.
+	srcStat, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	// If the source is not a directory, return an error.
+	if !srcStat.IsDir() {
+		return ErrIsNotDir
+	}
+
+	// Create the destination directory with the same permissions as the source directory.
+	if err := os.MkdirAll(dest, srcStat.Mode()); err != nil {
+		return err
+	}
+
+	// Walk through the source directory recursively.
+	err = filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		// If an error occurred during walking, return it.
+		if err != nil {
+			return err
+		}
+
+		// If the current item is not a regular file (e.g., a directory, symlink), skip it.
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		// Construct the destination path for the current file.
+		// `path[len(src)+1:]` gets the relative path from the source directory.
+		destPath := filepath.Join(dest, path[len(src)+1:])
+		// Create any necessary parent directories for the destination file with default permissions.
+		if err := os.MkdirAll(filepath.Dir(destPath), os.ModePerm); err != nil {
+			return err
+		}
+
+		// Open the source file for reading.
+		srcFile, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close() // Ensure the source file is closed.
+
+		// Create the destination file for writing.
+		destFile, err := os.Create(destPath)
+		if err != nil {
+			return err
+		}
+		defer destFile.Close() // Ensure the destination file is closed.
+
+		// Copy the contents from the source file to the destination file.
+		if _, err := io.Copy(destFile, srcFile); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	// If an error occurred during the walk, return it.
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ReadDir reads the directory specified by `dirName` and returns a list of matching file paths.
+// It uses `filepath.Glob` which means `dirName` can contain glob patterns (e.g., "mydir/*.txt").
+func ReadDir(dirName string) ([]string, error) {
+	files, err := filepath.Glob(dirName)
+	return files, err
+}
+
+// CreateFile creates a new file at the specified `filePath`.
+//
+// If the file already exists:
+//   - If 'force' is true, it overwrites the existing file.
+//   - If 'force' is false, it returns an error.
+func CreateFile(filePath string, force bool) (*os.File, error) {
+	// Check if the file exists.
+	_, err := os.Stat(filePath)
+	// If 'force' is false and the file exists, return an error.
+	if !force && os.IsExist(err) {
+		return nil, fmt.Errorf("error in getting file stat %s because of %v", filePath, err)
+	}
+	// Create the file. If it exists and 'force' is true, it will be truncated.
+	return os.Create(filePath)
+}
+
+// WriteFile writes the provided `contents` to the file at `filePath` with the given `permission`.
+// If the file does not exist, it will be created. If it exists, it will be truncated.
+func WriteFile(filePath string, permission os.FileMode, contents []byte) error {
+	return os.WriteFile(filePath, contents, permission)
+}
+
+// DeleteFile deletes the file at the specified `filePath`.
+// It returns an error if the file cannot be removed.
+func DeleteFile(filePath string) error {
+	return os.Remove(filePath)
+}
+
+// CopyFile copies a single file from `sourcePath` to `destPath`.
+// It reads the entire content of the source file into memory and then writes it to the destination.
+// The destination file will have default permissions (0644).
+func CopyFile(sourcePath, destPath string) error {
+	// Read the entire content of the source file.
+	input, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return err
+	}
+	// Write the content to the destination file with permissions 0644 (rw-r--r--).
+	return os.WriteFile(destPath, input, 0644)
+}
+
+// ReadFile reads the entire content of the file at `filePath` into a byte slice.
+// It returns the file content and any error encountered.
+func ReadFile(filePath string) ([]byte, error) {
+	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return contents, err
+}
+
+// SearchFiles searches for files with a specific `searchFile` name within `sourceDir`.
+// It excludes directories listed in `excludeDirs` from the search.
+// It returns a slice of full paths to the found files.
+func SearchFiles(sourceDir string, excludeDirs []string, searchFile string) ([]string, error) {
+	files := make([]string, 0) // Initialize an empty slice to store found file paths.
+
+	// Walk the directory tree rooted at `sourceDir`.
+	if err := filepath.WalkDir(sourceDir, fs.WalkDirFunc(func(path string, ds fs.DirEntry, err error) error {
+		// If an error occurred during walking, return it.
+		if err != nil {
+			return err
+		}
+
+		// Check if the current entry is a regular file, not within an excluded directory,
+		// and its base name matches `searchFile`.
+		if !ds.IsDir() && !isAncestor(excludeDirs, path) && filepath.Base(path) == searchFile {
+			files = append(files, path) // Add the file path to the results.
+		}
+		return nil
+	})); err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+// SearchFileExtensions searches for files with a specific `extension` within `sourceDir`.
+// It excludes directories listed in `excludeDirs` from the search.
+// It returns a slice of full paths to the found files.
+func SearchFileExtensions(sourceDir string, excludeDirs []string, extension string) ([]string, error) {
+	files := make([]string, 0) // Initialize an empty slice to store found file paths.
+
+	// Walk the directory tree rooted at `sourceDir`.
+	if err := filepath.WalkDir(sourceDir, fs.WalkDirFunc(func(path string, ds fs.DirEntry, err error) error {
+		// If an error occurred during walking, return it.
+		if err != nil {
+			return err
+		}
+
+		// Check if the current entry is a regular file, not within an excluded directory,
+		// and its extension matches the `extension`.
+		if !ds.IsDir() && !isAncestor(excludeDirs, path) && filepath.Ext(path) == extension {
+			files = append(files, path) // Add the file path to the results.
+		}
+		return nil
+	})); err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+// Pwd returns the present working directory (current directory).
+func Pwd() (string, error) {
+	return os.Getwd()
+}
+
+// Exists checks if a file or directory at the given `file` path exists.
+// It returns true if the file/directory exists, false if it does not,
+// and an error if there's any other issue checking its status.
+func Exists(file string) (bool, error) {
+	_, err := os.Stat(file)
+	if err == nil {
+		return true, nil // Path exists.
+	}
+	// If the error indicates that the file does not exist, return false.
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+// Cd changes the current working directory to `dir`.
+// It returns any error encountered during the change.
+func Cd(dir string) error {
+	return os.Chdir(dir)
+}
+
+// isAncestor checks if any of the `excludeDirs` are ancestors (or part of the path) of `path`.
+// It returns true if `path` contains any of the `excludeDirs` as a substring, false otherwise.
+func isAncestor(excludeDirs []string, path string) bool {
+	for _, excludeDir := range excludeDirs {
+		if strings.Contains(path, excludeDir) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ignite/ignite.go
+++ b/pkg/ignite/ignite.go
@@ -1,0 +1,92 @@
+// Package ignite provides a high-performance key/value data store
+// designed for fast read and write operations, inspired by Bitcask.
+// It combines an in-memory hash table (KeyDir/Index) with an append-only log
+// structure on disk to achieve high throughput. It is designed for applications
+// requiring fast read and write operations, such as caching, session management,
+// and real-time data processing, aiming to provide a simple, efficient, and
+// reliable solution for in-memory data storage in Go applications.
+package ignite
+
+import (
+	"context"
+	"time"
+
+	"github.com/iamNilotpal/ignite/internal/engine"
+	"github.com/iamNilotpal/ignite/pkg/logger"
+	"github.com/iamNilotpal/ignite/pkg/options"
+)
+
+// Represents an instance of the Ignite key/value data store.
+// It encapsulates the core engine responsible for data handling and
+// the configuration options for this specific database instance.
+//
+// Instance is the primary entry point for interacting with the Ignite store,
+// providing methods for setting, getting, and deleting key-value pairs.
+type Instance struct {
+	engine  *engine.Engine   // The underlying database engine handling read/write operations.
+	options *options.Options // Configuration options applied to this DB instance.
+}
+
+// Creates and initializes a new Ignite DB instance.
+func NewInstance(context context.Context, service string, opts ...options.OptionFunc) *Instance {
+	// Initialize a logger for the given service.
+	log := logger.New(service)
+
+	// Create a new internal engine with the initialized logger.
+	eng := engine.New(&engine.Config{Logger: log})
+
+	// Initialize default options.
+	defaultOpts := options.NewDefaultOptions()
+	// Apply any provided functional options to override defaults.
+	if len(opts) > 0 {
+		for _, opt := range opts {
+			opt(&defaultOpts)
+		}
+	}
+
+	return &Instance{
+		engine:  eng,
+		options: &defaultOpts,
+	}
+}
+
+// Set stores a key-value pair in the database.
+// If the key already exists, its value will be updated.
+// The operation is durable and will be written to the append-only log.
+func (i *Instance) Set(context context.Context, key string, value []byte) error {
+	return nil
+}
+
+// SetX stores a key-value pair with an expiration time.
+// The entry will automatically be considered expired and inaccessible
+// after the specified duration from the time of setting.
+// If the key already exists, its value and expiry will be updated.
+func (i *Instance) SetX(ctx context.Context, key string, value []byte, expiry time.Duration) error {
+	return nil
+}
+
+// Get retrieves the value associated with the given key.
+func (i *Instance) Get(ctx context.Context, key string) ([]byte, error) {
+	return nil, nil
+}
+
+// Delete removes a key-value pair from the database.
+// The operation marks the key as deleted and will eventually be
+// removed during compaction.
+func (i *Instance) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+// Close gracefully shuts down the Ignite DB instance, releasing all
+// associated resources, flushing any pending writes, and ensuring data
+// durability.
+//
+// It should be called when the DB instance is no longer needed to prevent
+// resource leaks and data corruption.
+func (i *Instance) Close(ctx context.Context) error {
+	// TODO: Implement actual shutdown logic here.
+	// - Flushing in-memory buffers to disk.
+	// - Closing open file handles in the engine.
+	// - Waiting for any background goroutines (like compaction) to finish or be cancelled.
+	return nil
+}

--- a/pkg/options/defaults.go
+++ b/pkg/options/defaults.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	// Specifies the default base directory where IgniteDB will store its data files.
 	// If no other directory is specified during initialization, this path will be used.
-	DefaultDataDir = "/ignitedb"
+	DefaultDataDir = "/var/lib/ignitedb"
 
 	// Defines the default time duration between automatic compaction operations.
 	// By default, compaction will run every 5 hours.
@@ -22,7 +22,7 @@ const (
 
 	// Specifies the default subdirectory within the main data directory
 	// where segment files will be stored.
-	DefaultSegmentDirectory = "/ignitedb/segments"
+	DefaultSegmentDirectory = "/segments"
 
 	// Defines the default prefix for segment file names.
 	// For example, a segment file might be named "segment-00001.db".

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,7 +29,7 @@ type segmentOptions struct {
 	// Defines the filename prefix for segment files.
 	// Final filename will be: `prefix_segmentId_timestamp.seg`
 	//
-	// Default: "ignite"
+	// Default: "segment"
 	//
 	// Example: If Prefix is "mydata", a segment file might be "mydata_000001_20240525232100.seg".
 	Prefix string `json:"prefix"`


### PR DESCRIPTION
- Set: Stores a key-value pair, ensuring durability through the append-only log.
- SetX: Stores a key-value pair with an expiration time.
- Get: Retrieves the value associated with a given key.
- Delete: Marks a key as deleted, with actual removal during compaction.
- Close: Gracefully shuts down the database, releasing resources and ensuring data durability.
- Add file system utility methods.